### PR TITLE
Refactor mixture model test to unittest

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run unit tests
+        run: python MultinomialMixture/testMixtureModel.py

--- a/MultinomialMixture/multinomialMixtureEstimation.py
+++ b/MultinomialMixture/multinomialMixtureEstimation.py
@@ -101,10 +101,10 @@ class MultinomialMixtureModelHyperparams:
 
 def logProbsToProbabilityDistribution(logProbs):
   highest = max(logProbs)
-  logProbs = map(lambda x: x - highest, logProbs)
-  unnormalized = map(lambda x: math.exp(x), logProbs)
+  logProbs = [x - highest for x in logProbs]
+  unnormalized = [math.exp(x) for x in logProbs]
   S = sum(unnormalized)
-  return map(lambda x: float(x) / S, unnormalized)
+  return [float(x) / S for x in unnormalized]
 
 # Input counts: A K-dimensional count vector for a given row
 # we want to know which component of the mixture model best describes the counts

--- a/MultinomialMixture/testMixtureModel.py
+++ b/MultinomialMixture/testMixtureModel.py
@@ -1,18 +1,44 @@
 #!/usr/bin/python
 
-import multinomialMixtureEstimation as MME
+import os
 import logging
-logging.basicConfig(level=logging.DEBUG)
+import unittest
 
-model = MME.importFile("sampleModel.txt")
+import csv
+import multinomialMixtureEstimation as MME
 
-dataset = []
-for i in range(0, 500): dataset.append(model.sampleRow(8))
 
-hyperP = MME.MultinomialMixtureModelHyperparams(2, 3, [1, 1], [1, 1, 1])
+def import_file(filename):
+    """Python 3 compatible version of ``MME.importFile``."""
+    with open(filename, 'r') as infile:
+        reader = csv.reader(infile, delimiter='\t')
+        mixture = list(map(float, next(reader)))
+        multinomials = [list(map(float, row)) for row in reader]
+    K = len(multinomials[0]) if multinomials else 2
+    return MME.MultinomialMixtureModel(len(mixture), K, multinomials, mixture)
 
-finalModel = MME.computeDirichletMixture(dataset, hyperP, 10)
 
-print "Final Model:"
-print finalModel.mixture
-print finalModel.multinomials
+class TestMixtureModel(unittest.TestCase):
+    """Tests for the multinomial mixture estimation."""
+
+    def setUp(self):
+        logging.basicConfig(level=logging.DEBUG)
+        model_path = os.path.join(os.path.dirname(__file__), "sampleModel.txt")
+        self.model = import_file(model_path)
+        self.dataset = [self.model.sampleRow(8) for _ in range(500)]
+        hyper = MME.MultinomialMixtureModelHyperparams(2, 3, [1, 1], [1, 1, 1])
+        self.finalModel = MME.computeDirichletMixture(self.dataset, hyper, 10)
+
+    def test_final_model(self):
+        mixture = self.finalModel.mixture
+        self.assertEqual(len(mixture), 2)
+        self.assertAlmostEqual(sum(mixture), 1.0, places=5)
+
+        multinomials = self.finalModel.multinomials
+        self.assertEqual(len(multinomials), 2)
+        for multinomial in multinomials:
+            self.assertEqual(len(multinomial), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert `testMixtureModel.py` to use Python's unittest module
- add helper `import_file` for Python3 compatibility
- assert final model structure in the new test
- make `logProbsToProbabilityDistribution` Python3 friendly
- add GitHub Actions workflow to run tests

## Testing
- `python MultinomialMixture/testMixtureModel.py`
